### PR TITLE
Add simple dossier, object, and relationship pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,49 @@
+from flask import Flask, render_template, request, redirect, url_for
+
+app = Flask(__name__)
+
+dossiers = {}
+objects = {}
+relationships = []
+
+def next_id(entity):
+    return str(len(entity) + 1)
+
+@app.route('/')
+def index():
+    return redirect(url_for('dossiers_view'))
+
+@app.route('/dossiers', methods=['GET', 'POST'])
+def dossiers_view():
+    if request.method == 'POST':
+        name = request.form['name']
+        did = next_id(dossiers)
+        dossiers[did] = {'name': name, 'objects': [], 'relationships': []}
+        return redirect(url_for('dossiers_view'))
+    return render_template('dossiers.html', title='Dossiers', dossiers=dossiers)
+
+@app.route('/objects', methods=['GET', 'POST'])
+def objects_view():
+    if request.method == 'POST':
+        name = request.form['name']
+        oid = next_id(objects)
+        objects[oid] = {'name': name, 'relationships': []}
+        return redirect(url_for('objects_view'))
+    return render_template('objects.html', title='Objects', objects=objects)
+
+@app.route('/relationships', methods=['GET', 'POST'])
+def relationships_view():
+    if request.method == 'POST':
+        dossier_id = request.form['dossier_id']
+        object_id = request.form['object_id']
+        rel = {'dossier': dossier_id, 'object': object_id}
+        relationships.append(rel)
+        dossiers[dossier_id]['relationships'].append(rel)
+        dossiers[dossier_id]['objects'].append(object_id)
+        objects[object_id]['relationships'].append(rel)
+        return redirect(url_for('relationships_view'))
+    return render_template('relationships.html', title='Relationships',
+                           dossiers=dossiers, objects=objects, relationships=relationships)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 2em; }
+nav a { margin-right: 1em; }
+main { margin-top: 1em; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <nav>
+        <a href="/dossiers">Dossiers</a> |
+        <a href="/objects">Objects</a> |
+        <a href="/relationships">Relationships</a>
+    </nav>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/templates/dossiers.html
+++ b/templates/dossiers.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Dossiers</h1>
+<form method="post">
+    <input type="text" name="name" placeholder="Dossier Name" required>
+    <button type="submit">Add Dossier</button>
+</form>
+<ul>
+{% for d in dossiers.values() %}
+    <li>{{ d['name'] }} (Objects: {{ d['objects']|length }}, Relationships: {{ d['relationships']|length }})</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/objects.html
+++ b/templates/objects.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Objects</h1>
+<form method="post">
+    <input type="text" name="name" placeholder="Object Name" required>
+    <button type="submit">Add Object</button>
+</form>
+<ul>
+{% for o in objects.values() %}
+    <li>{{ o['name'] }} (Relationships: {{ o['relationships']|length }})</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/relationships.html
+++ b/templates/relationships.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Relationships</h1>
+<form method="post">
+    <label>Dossier:
+        <select name="dossier_id">
+        {% for id, d in dossiers.items() %}
+            <option value="{{ id }}">{{ d['name'] }}</option>
+        {% endfor %}
+        </select>
+    </label>
+    <label>Object:
+        <select name="object_id">
+        {% for id, o in objects.items() %}
+            <option value="{{ id }}">{{ o['name'] }}</option>
+        {% endfor %}
+        </select>
+    </label>
+    <button type="submit">Create Relationship</button>
+</form>
+<ul>
+{% for r in relationships %}
+    <li>{{ dossiers[r['dossier']]['name'] }} - {{ objects[r['object']]['name'] }}</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask web app showing Dossiers, Objects and Relationships pages
- include base layout and simple CSS styling
- pages let you add items and connect them

## Testing
- `python -m py_compile app.py`
- `pip install flask` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e2def48d48324a3184d975d23fe29